### PR TITLE
Add RocksDB checkpoint and table size approximation

### DIFF
--- a/chainweb-storage.cabal
+++ b/chainweb-storage.cabal
@@ -35,6 +35,7 @@ library
         Data.CAS.Forgetful
         Data.CAS.HashMap
         Data.CAS.RocksDB
+        Data.CAS.RocksDB.Checkpoint
         Data.DedupStore
     build-depends:
         , base >=4.10 && <4.16

--- a/src/Data/CAS/RocksDB/Checkpoint.hs
+++ b/src/Data/CAS/RocksDB/Checkpoint.hs
@@ -1,0 +1,58 @@
+module Data.CAS.RocksDB.Checkpoint
+  ( checkpointRocksDb
+  ) where
+
+import Control.Exception
+import Control.Monad
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Char8 as BSC
+import Foreign.C
+import Foreign.Marshal
+import Foreign.Ptr
+import Foreign.Storable
+
+import Database.RocksDB.C(RocksDBPtr)
+import Database.RocksDB.Internal(DB(..))
+
+import Data.CAS.RocksDB(RocksDb(..))
+
+data Checkpoint
+
+foreign import ccall safe "rocksdb\\c.h rocksdb_checkpoint_object_create" 
+  rocksdb_checkpoint_object_create :: RocksDBPtr -> Ptr CString -> IO (Ptr Checkpoint)
+
+foreign import ccall safe "rocksdb\\c.h rocksdb_checkpoint_create"
+  rocksdb_checkpoint_create :: Ptr Checkpoint -> CString -> CULong -> Ptr CString -> IO ()
+
+foreign import ccall safe "rocksdb\\c.h rocksdb_checkpoint_object_destroy"
+  rocksdb_checkpoint_object_destroy :: Ptr Checkpoint -> IO ()
+
+checked :: String -> Ptr CString -> IO a -> IO a
+checked whatWasIDoing errPtr act = do
+  r <- act
+  err <- peek errPtr
+  unless (err == nullPtr) $ do
+    errStr <- BS.packCString err
+    let msg = unwords ["error while", whatWasIDoing <> ":", BSC.unpack errStr]
+    free err
+    fail msg
+  return r
+
+-- to unconditionally flush the WAL log, set logSizeFlushThreshold to zero. 
+-- to *never* flush the WAL log, set logSizeFlushThreshold to maxBound :: CULong.
+checkpointRocksDb :: RocksDb -> CULong -> FilePath -> IO ()
+checkpointRocksDb RocksDb { _rocksDbHandle = DB dbPtr _ } logSizeFlushThreshold path = 
+  alloca (\errPtr -> do
+    poke errPtr (nullPtr :: CString)
+    let 
+      mkCheckpointObject = 
+        checked "creating checkpoint object" errPtr $ 
+          rocksdb_checkpoint_object_create dbPtr errPtr
+      mkCheckpoint cp =
+        withCString path (\path' -> 
+          checked "creating checkpoint" errPtr $ 
+            rocksdb_checkpoint_create cp path' logSizeFlushThreshold errPtr
+          )
+    bracket mkCheckpointObject rocksdb_checkpoint_object_destroy mkCheckpoint 
+  )
+


### PR DESCRIPTION
See https://github.com/facebook/rocksdb/blob/2e09a54c4fb82e88bcaa3e7cfa8ccbbbbf3635d5/docs/_posts/2015-11-10-use-checkpoints-for-efficient-snapshots.markdown for an overview of this feature.

In short, RocksDB checkpoints let us atomically create copies of a database without a big storage cost, as long as the database is on the same partition as the checkpoint. Snapshots, except that snapshots are a different feature of RocksDB which don't persist on disk, so they don't do the same thing. We should be able to use these for efficient backups.

Not sure if this is best here or in chainweb-node.