### PR TITLE
Table table

### DIFF
--- a/src/Data/CAS/RocksDB.hs
+++ b/src/Data/CAS/RocksDB.hs
@@ -319,9 +319,9 @@ newTable
     -> [B.ByteString]
     -> IO (RocksDbTable k v)
 newTable db valCodec keyCodec namespace = do
-  table <- evaluate (unregisteredNewTable db valCodec keyCodec namespace)
-  tableInsert (tablesTable db) namespace ()
-  return table
+    table <- evaluate (unregisteredNewTable db valCodec keyCodec namespace)
+    tableInsert (tablesTable db) namespace ()
+    return table
 
 -- | Create a new 'RocksDbTable' in the given 'RocksDb' without registering it with the "tables" table.
 --
@@ -799,42 +799,40 @@ decIterKey it k = case B.splitAt (B.length namespace) k of
 data Checkpoint
 
 foreign import ccall unsafe "rocksdb\\c.h rocksdb_checkpoint_object_create" 
-  rocksdb_checkpoint_object_create :: C.RocksDBPtr -> Ptr CString -> IO (Ptr Checkpoint)
+    rocksdb_checkpoint_object_create :: C.RocksDBPtr -> Ptr CString -> IO (Ptr Checkpoint)
 
 foreign import ccall unsafe "rocksdb\\c.h rocksdb_checkpoint_create"
-  rocksdb_checkpoint_create :: Ptr Checkpoint -> CString -> CULong -> Ptr CString -> IO ()
+    rocksdb_checkpoint_create :: Ptr Checkpoint -> CString -> CULong -> Ptr CString -> IO ()
 
 foreign import ccall unsafe "rocksdb\\c.h rocksdb_checkpoint_object_destroy"
-  rocksdb_checkpoint_object_destroy :: Ptr Checkpoint -> IO ()
+    rocksdb_checkpoint_object_destroy :: Ptr Checkpoint -> IO ()
 
-checked :: String -> Ptr CString -> IO a -> IO a
+checked :: HasCallStack => String -> Ptr CString -> IO a -> IO a
 checked whatWasIDoing errPtr act = do
-  r <- act
-  err <- peek errPtr
-  unless (err == nullPtr) $ do
-    errStr <- B.packCString err
-    let msg = unwords ["error while", whatWasIDoing <> ":", B8.unpack errStr]
-    free err
-    fail msg
-  return r
+    r <- act
+    err <- peek errPtr
+    unless (err == nullPtr) $ do
+        errStr <- B.packCString err
+        let msg = unwords ["Data.CAS.RocksDB.checked: error while", whatWasIDoing <> ":", B8.unpack errStr]
+        free err
+        error msg
+    return r
 
 -- to unconditionally flush the WAL log before making the checkpoint, set logSizeFlushThreshold to zero. 
 -- to *never* flush the WAL log, set logSizeFlushThreshold to maxBound :: CULong.
 checkpointRocksDb :: RocksDb -> CULong -> FilePath -> IO ()
 checkpointRocksDb RocksDb { _rocksDbHandle = R.DB dbPtr _ } logSizeFlushThreshold path = 
-    alloca (\errPtr -> do
-      poke errPtr (nullPtr :: CString)
-      let 
-          mkCheckpointObject = 
-            checked "creating checkpoint object" errPtr $ 
-              rocksdb_checkpoint_object_create dbPtr errPtr
-          mkCheckpoint cp =
-            withCString path (\path' -> 
-              checked "creating checkpoint" errPtr $ 
-                rocksdb_checkpoint_create cp path' logSizeFlushThreshold errPtr
-              )
-      bracket mkCheckpointObject rocksdb_checkpoint_object_destroy mkCheckpoint 
-    )
+    alloca $ \errPtr -> do
+        poke errPtr (nullPtr :: CString)
+        let 
+            mkCheckpointObject = 
+                checked "creating checkpoint object" errPtr $ 
+                    rocksdb_checkpoint_object_create dbPtr errPtr
+            mkCheckpoint cp =
+                withCString path $ \path' -> 
+                    checked "creating checkpoint" errPtr $ 
+                        rocksdb_checkpoint_create cp path' logSizeFlushThreshold errPtr
+        bracket mkCheckpointObject rocksdb_checkpoint_object_destroy mkCheckpoint 
 
 foreign import ccall unsafe "rocksdb\\c.h rocksdb_approximate_sizes" 
     rocksdb_approximate_sizes
@@ -848,14 +846,11 @@ foreign import ccall unsafe "rocksdb\\c.h rocksdb_approximate_sizes"
         -> {- errptr -} Ptr CString 
         -> IO ()
 
-approxTableSizeRocksDb :: RocksDb -> RocksDbTable k v -> IO (Maybe CULong)
+approxTableSizeRocksDb :: RocksDb -> RocksDbTable k v -> IO CULong
 approxTableSizeRocksDb RocksDb { _rocksDbHandle = R.DB dbPtr _ } table = do
-    bounds <- withTableIter table $ \iter -> 
-        (,)
-            <$> (tableIterFirst iter *> R.iterKey (_rocksDbTableIter iter)) 
-            <*> (tableIterLast iter *> R.iterKey (_rocksDbTableIter iter))
-    forM (sequenceOf each bounds) $ \(minKey, maxKey) ->
-        alloca $ \rangeStartPtr ->
+    (minKey, maxKey) <- withTableIter table $ \iter -> 
+        return (_rocksDbTableIterNamespace iter, namespaceLast iter)
+    alloca $ \rangeStartPtr ->
         alloca $ \rangeStartLengthPtr ->
         alloca $ \rangeEndPtr -> 
         alloca $ \rangeEndLengthPtr -> 

--- a/src/Data/CAS/RocksDB.hs
+++ b/src/Data/CAS/RocksDB.hs
@@ -53,6 +53,7 @@ module Data.CAS.RocksDB
 , Codec(..)
 , RocksDbTable
 , newTable
+, tablesTable
 , tableLookup
 , tableInsert
 , tableDelete

--- a/src/Data/CAS/RocksDB.hs
+++ b/src/Data/CAS/RocksDB.hs
@@ -291,7 +291,7 @@ instance NoThunks (Codec a) where
 data RocksDbTable k v = RocksDbTable
     { _rocksDbTableValueCodec :: !(Codec v)
     , _rocksDbTableKeyCodec :: !(Codec k)
-    , _rocksDbTableName :: !B.ByteString
+    , _rocksDbTableNamespace :: !B.ByteString
     , _rocksDbTableDb :: !R.DB
     }
 
@@ -338,7 +338,7 @@ unregisteredNewTable db valCodec keyCodec namespace
     | otherwise
         = RocksDbTable valCodec keyCodec ns (_rocksDbHandle db)
   where
-    ns = _rocksDbNamespace db <> "-" <> B.intercalate "/" namespace <> "$"
+    ns = _rocksDbNamespace db <> "-" <> B.intercalate "/" namespace
 {-# INLINE unregisteredNewTable #-}
 
 tablesTable
@@ -464,7 +464,7 @@ createTableIter db = do
     !tit <- RocksDbTableIter
         (_rocksDbTableValueCodec db)
         (_rocksDbTableKeyCodec db)
-        (_rocksDbTableName db)
+        (_rocksDbTableNamespace db)
         <$> I.createIter (_rocksDbTableDb db) R.defaultReadOptions
     tableIterFirst tit
     return tit
@@ -508,14 +508,14 @@ tableIterSeek it = I.iterSeek (_rocksDbTableIter it) . encIterKey it
 --
 tableIterFirst :: MonadIO m => RocksDbTableIter k v -> m ()
 tableIterFirst it
-    = I.iterSeek (_rocksDbTableIter it) (_rocksDbTableIterNamespace it)
+    = I.iterSeek (_rocksDbTableIter it) $ namespaceFirst (_rocksDbTableIterNamespace it)
 {-# INLINE tableIterFirst #-}
 
 -- | Seek to the last value in a 'RocksDbTable'
 --
 tableIterLast :: MonadIO m => RocksDbTableIter k v -> m ()
 tableIterLast it = do
-    I.iterSeek (_rocksDbTableIter it) (namespaceLast it)
+    I.iterSeek (_rocksDbTableIter it) $ namespaceLast (_rocksDbTableIterNamespace it)
     I.iterPrev (_rocksDbTableIter it)
 {-# INLINE tableIterLast #-}
 
@@ -741,9 +741,9 @@ encVal = _codecEncode . _rocksDbTableValueCodec
 {-# INLINE encVal #-}
 
 encKey :: RocksDbTable k v -> k -> B.ByteString
-encKey it k = prefix <> _codecEncode (_rocksDbTableKeyCodec it) k
+encKey it k = namespaceFirst ns <> _codecEncode (_rocksDbTableKeyCodec it) k
   where
-    prefix = _rocksDbTableName it
+    ns = _rocksDbTableNamespace it
 {-# INLINE encKey #-}
 
 decVal :: MonadThrow m => RocksDbTable k v -> B.ByteString -> m v
@@ -753,14 +753,18 @@ decVal tbl = _codecDecode $ _rocksDbTableValueCodec tbl
 -- -------------------------------------------------------------------------- --
 -- Iter Utils
 
-namespaceLast :: RocksDbTableIter k v -> B.ByteString
-namespaceLast it = B.init (_rocksDbTableIterNamespace it) <> "%"
+namespaceFirst :: B.ByteString -> B.ByteString
+namespaceFirst ns = ns <> "$"
+{-# INLINE namespaceFirst #-}
+
+namespaceLast :: B.ByteString -> B.ByteString
+namespaceLast ns = ns <> "%"
 {-# INLINE namespaceLast #-}
 
 encIterKey :: RocksDbTableIter k v -> k -> B.ByteString
-encIterKey it k = prefix <> _codecEncode (_rocksDbTableIterKeyCodec it) k
+encIterKey it k = namespaceFirst ns <> _codecEncode (_rocksDbTableIterKeyCodec it) k
   where
-    prefix = _rocksDbTableIterNamespace it
+    ns = _rocksDbTableIterNamespace it
 {-# INLINE encIterKey #-}
 
 decIterVal :: MonadThrow m => RocksDbTableIter k v -> B.ByteString -> m v
@@ -778,22 +782,22 @@ checkIterKey it k = maybe False (const True) $ decIterKey it k
 -- iterators that point outside their respective namespace key range.
 --
 tryDecIterKey :: MonadThrow m => RocksDbTableIter k v -> B.ByteString -> m (Maybe k)
-tryDecIterKey it k = case B.splitAt (B.length namespace) k of
+tryDecIterKey it k = case B.splitAt (B.length prefix) k of
     (a, b)
-        | a /= namespace -> return Nothing
+        | a /= prefix -> return Nothing
         | otherwise -> Just <$> _codecDecode (_rocksDbTableIterKeyCodec it) b
   where
-    namespace = _rocksDbTableIterNamespace it
+    prefix = namespaceFirst $ _rocksDbTableIterNamespace it
 {-# INLINE tryDecIterKey #-}
 
 decIterKey :: MonadThrow m => RocksDbTableIter k v -> B.ByteString -> m k
-decIterKey it k = case B.splitAt (B.length namespace) k of
+decIterKey it k = case B.splitAt (B.length prefix) k of
     (a, b)
-        | a == namespace -> _codecDecode (_rocksDbTableIterKeyCodec it) b
+        | a == prefix -> _codecDecode (_rocksDbTableIterKeyCodec it) b
         | otherwise -> throwM
-            $ RocksDbTableIterInvalidKeyNamespace (Expected namespace) (Actual a)
+            $ RocksDbTableIterInvalidKeyNamespace (Expected $ _rocksDbTableIterNamespace it) (Actual a)
   where
-    namespace = _rocksDbTableIterNamespace it
+    prefix = namespaceFirst $ _rocksDbTableIterNamespace it
 {-# INLINE decIterKey #-}
 
 data Checkpoint
@@ -848,16 +852,14 @@ foreign import ccall unsafe "rocksdb\\c.h rocksdb_approximate_sizes"
 
 approxTableSizeRocksDb :: RocksDb -> RocksDbTable k v -> IO CULong
 approxTableSizeRocksDb RocksDb { _rocksDbHandle = R.DB dbPtr _ } table = do
-    (minKey, maxKey) <- withTableIter table $ \iter -> 
-        return (_rocksDbTableIterNamespace iter, namespaceLast iter)
     alloca $ \rangeStartPtr ->
         alloca $ \rangeStartLengthPtr ->
         alloca $ \rangeEndPtr -> 
         alloca $ \rangeEndLengthPtr -> 
         alloca $ \sizePtr ->
         alloca $ \errPtr -> 
-        B.useAsCStringLen minKey $ \(minKeyPtr, minKeyLen) ->
-        B.useAsCStringLen maxKey $ \(maxKeyPtr, maxKeyLen) -> do
+        B.useAsCStringLen (namespaceFirst $ _rocksDbTableNamespace table) $ \(minKeyPtr, minKeyLen) ->
+        B.useAsCStringLen (namespaceLast $ _rocksDbTableNamespace table) $ \(maxKeyPtr, maxKeyLen) -> do
             poke rangeStartPtr minKeyPtr
             poke rangeStartLengthPtr (fromIntegral minKeyLen :: CSize)
             poke rangeEndPtr maxKeyPtr

--- a/src/Data/DedupStore.hs
+++ b/src/Data/DedupStore.hs
@@ -123,12 +123,15 @@ newDedupStore
     -> Codec v
     -> Codec k
     -> [B.ByteString]
-    -> DedupStore k v
-newDedupStore rdb vc kc n = DedupStore
-    { _dedupRoots = newTable rdb dedupHashCodec kc (n <> ["roots"])
-    , _dedupChunks = newCas rdb dedupChunkCodec dedupHashCodec (n <> ["chunks"])
-    , _dedupValueCodec = vc
-    }
+    -> IO (DedupStore k v)
+newDedupStore rdb vc kc n = do 
+    roots <- newTable rdb dedupHashCodec kc (n <> ["roots"])
+    chunks <- newCas rdb dedupChunkCodec dedupHashCodec (n <> ["chunks"])
+    pure DedupStore
+        { _dedupRoots = roots
+        , _dedupChunks = chunks
+        , _dedupValueCodec = vc
+        }
   where
     dedupHashCodec = Codec
         { _codecEncode = _dedupHashBytes

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -74,7 +74,7 @@ intCodec = Codec
     (either (throwM . CodecException) return . readEither @Int . B8.unpack)
 
 intTable :: RocksDb -> B8.ByteString -> RocksDbTable Int Int
-intTable db tableName = newTable db intCodec intCodec [tableName]
+intTable db tableName = unregisteredNewTable db intCodec intCodec [tableName]
 
 -- -------------------------------------------------------------------------- --
 -- Tests


### PR DESCRIPTION
A table listing all of our tables lets us easily keep track of their sizes without centralizing the list of extant tables somewhere in the code. Depends on #9, because it's going to be used with table size approximation anyway.