### PR TITLE
stop using newer rocksdb features, stop building rocksdb

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -3,4 +3,4 @@ packages: chainweb-storage.cabal
 source-repository-package
     type: git
     location: https://github.com/kadena-io/rocksdb-haskell.git
-    tag: b35d82bad2194a916c821457069388410662b58c
+    tag: 1702d0787e043d81ac940c27b142c08acfffc4b0

--- a/src/Chainweb/Storage/Table/RocksDB.hs
+++ b/src/Chainweb/Storage/Table/RocksDB.hs
@@ -453,9 +453,6 @@ instance IterableTable (RocksDbTable k v) (RocksDbTableIter k v) k v where
         readOptions = fold
             [ R.setLowerBound (namespaceFirst $ _rocksDbTableNamespace db)
             , R.setUpperBound (namespaceLast $ _rocksDbTableNamespace db)
-            -- TODO: this setting tells rocksdb to use prefix seek *when it can*.
-            -- the question remains: is it actually being used?
-            , R.setAutoPrefixMode True
             ]
         makeTableIter =
             RocksDbTableIter


### PR DESCRIPTION
rocksdb-haskell pin needs changing once the corresponding rocksdb-haskell PR is merged.